### PR TITLE
Architizer's changes for Feedly (Stream Framework)

### DIFF
--- a/stream_framework/activity.py
+++ b/stream_framework/activity.py
@@ -411,7 +411,7 @@ class AggregatedActivity(BaseActivity):
         verbs = [v.past_tense for v in self.verbs]
         actor_ids = self.actor_ids
         object_ids = self.object_ids
-        actors = ','.join(map(str, actor_ids))
+        actors = '|'.join(map(str, actor_ids))
         message = 'AggregatedActivity(%s-%s) Actors %s: Objects %s' % (
-            self.group, ','.join(verbs), actors, object_ids)
+            self.group, '|'.join(verbs), actors, object_ids)
         return message

--- a/stream_framework/activity.py
+++ b/stream_framework/activity.py
@@ -157,16 +157,16 @@ class AggregatedActivity(BaseActivity):
     '''
     max_aggregated_activities_length = MAX_AGGREGATED_ACTIVITIES_LENGTH
 
-    def __init__(self, group, activities=None, created_at=None, updated_at=None):
+    def __init__(self, group, activities=None, created_at=None, updated_at=None, read_at=None, seen_at=None):
         self.group = group
         self.activities = activities or []
         self.created_at = created_at
         self.updated_at = updated_at
         # if the user opened the notification window and browsed over the
         # content
-        self.seen_at = None
+        self.seen_at = seen_at
         # if the user engaged with the content
-        self.read_at = None
+        self.read_at = read_at
         # activity
         self.minimized_activities = 0
         self.dehydrated = False

--- a/stream_framework/serializers/activity_serializer.py
+++ b/stream_framework/serializers/activity_serializer.py
@@ -34,11 +34,11 @@ class ActivitySerializer(BaseSerializer):
             if six.PY3:
                 pickle_string = pickle_string.decode('latin1')
         parts += [activity_time, pickle_string]
-        serialized_activity = ','.join(map(str, parts))
+        serialized_activity = '|'.join(map(str, parts))
         return serialized_activity
 
     def loads(self, serialized_activity):
-        parts = serialized_activity.split(',')
+        parts = serialized_activity.split('|')
         # convert these to ids
         actor_id, verb_id, object_id, target_id = map(
             int, parts[:4])

--- a/stream_framework/serializers/activity_serializer.py
+++ b/stream_framework/serializers/activity_serializer.py
@@ -44,7 +44,7 @@ class ActivitySerializer(BaseSerializer):
             int, parts[:4])
         activity_datetime = epoch_to_datetime(float(parts[4]))
         # just in case the original pickle_string contains a comma
-        pickle_string = ','.join(parts[5:])
+        pickle_string = '|'.join(parts[5:])
         if not target_id:
             target_id = None
         verb = get_verb_by_id(verb_id)

--- a/stream_framework/serializers/aggregated_activity_serializer.py
+++ b/stream_framework/serializers/aggregated_activity_serializer.py
@@ -23,7 +23,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
     #: indicates if dumps returns dehydrated aggregated activities
     dehydrate = True
     identifier = 'v3'
-    reserved_characters = [';', ',', ';;']
+    reserved_characters = ['\t', '|', '\t\t']
     date_fields = ['created_at', 'updated_at', 'seen_at', 'read_at']
 
     activity_serializer_class = ActivitySerializer
@@ -34,7 +34,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
         activity_serializer = self.activity_serializer_class(Activity)
         # start by storing the group
         parts = [aggregated.group]
-        check_reserved(aggregated.group, [';;'])
+        check_reserved(aggregated.group, ['\t\t'])
 
         # store the dates
         for date_field in self.date_fields:
@@ -55,7 +55,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
         else:
             for activity in aggregated.activities:
                 serialized = activity_serializer.dumps(activity)
-                check_reserved(serialized, [';', ';;'])
+                check_reserved(serialized, ['\t', '\t\t'])
                 serialized_activities.append(serialized)
 
         serialized_activities_part = ';'.join(serialized_activities)
@@ -65,7 +65,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
         parts.append(aggregated.minimized_activities)
 
         # stick everything together
-        serialized_aggregated = ';;'.join(map(str, parts))
+        serialized_aggregated = '\t\t'.join(map(str, parts))
         serialized = '%s%s' % (self.identifier, serialized_aggregated)
         return serialized
 
@@ -73,7 +73,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
         activity_serializer = self.activity_serializer_class(Activity)
         try:
             serialized_aggregated = serialized_aggregated[2:]
-            parts = serialized_aggregated.split(';;')
+            parts = serialized_aggregated.split('\t\t')
             # start with the group
             group = parts[0]
             aggregated = self.aggregated_activity_class(group)
@@ -87,7 +87,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
                 setattr(aggregated, k, date_value)
 
             # write the activities
-            serializations = parts[5].split(';')
+            serializations = parts[5].split('\t')
             if self.dehydrate:
                 activity_ids = list(map(int, serializations))
                 aggregated._activity_ids = activity_ids

--- a/stream_framework/serializers/aggregated_activity_serializer.py
+++ b/stream_framework/serializers/aggregated_activity_serializer.py
@@ -58,7 +58,7 @@ class AggregatedActivitySerializer(BaseAggregatedSerializer):
                 check_reserved(serialized, ['\t', '\t\t'])
                 serialized_activities.append(serialized)
 
-        serialized_activities_part = ';'.join(serialized_activities)
+        serialized_activities_part = '\t'.join(serialized_activities)
         parts.append(serialized_activities_part)
 
         # add the minified activities

--- a/stream_framework/serializers/cassandra/aggregated_activity_serializer.py
+++ b/stream_framework/serializers/cassandra/aggregated_activity_serializer.py
@@ -16,7 +16,9 @@ class CassandraAggregatedActivitySerializer(AggregatedActivitySerializer):
             activities=activities,
             group=aggregated.group,
             created_at=aggregated.created_at,
-            updated_at=aggregated.updated_at
+            updated_at=aggregated.updated_at,
+            seen_at=aggregated.seen_at,
+            read_at=aggregated.read_at
         )
         return model_instance
 
@@ -27,5 +29,7 @@ class CassandraAggregatedActivitySerializer(AggregatedActivitySerializer):
             activities=activities,
             created_at=serialized_aggregated.created_at,
             updated_at=serialized_aggregated.updated_at,
+            seen_at=serialized_aggregated.seen_at,
+            read_at=serialized_aggregated.read_at
         )
         return aggregated

--- a/stream_framework/storage/cassandra/models.py
+++ b/stream_framework/storage/cassandra/models.py
@@ -43,3 +43,5 @@ class AggregatedActivity(BaseActivity):
     created_at = columns.DateTime(required=False)
     group = columns.Ascii(required=False)
     updated_at = columns.DateTime(required=False)
+    seen_at = columns.DateTime(required=False)
+    read_at = columns.DateTime(required=False)

--- a/stream_framework/storage/cassandra/timeline_storage.py
+++ b/stream_framework/storage/cassandra/timeline_storage.py
@@ -72,9 +72,6 @@ class CassandraTimelineStorage(BaseTimelineStorage):
 
     """
 
-    from stream_framework.storage.cassandra.connection import setup_connection
-    setup_connection()
-
     default_serializer_class = CassandraActivitySerializer
     insert_batch_size = 100
 
@@ -203,7 +200,9 @@ class CassandraTimelineStorage(BaseTimelineStorage):
 
         if stop is not None:
             limit = (stop - (start or 0))
+            query = query.limit(limit)
 
-        for activity in query.order_by(*ordering).limit(limit):
+        for activity in query.order_by(*ordering):
             results.append([activity.activity_id, activity])
+
         return results


### PR DESCRIPTION
apply all our changes for Feedly to Stream Framework
These commits are applied:

b22a992 changed separatiors in new files: ',' -> '|', ';' -> '\t'

4c2a54f Merge pull request #1 from manelore/merge-with-master
dc4a5cf Removed setup_connection from timeline storage
b56666c Merge branch 'architizer/master' into 'stream-framework/master'
55a1b2f Changed delimiter from ; to \t
e180611 changes serializer delimiter to | from ,  was having trouble with data containing ,
ac61f50 fixes small bug with NotificationFeed.add_many
f61c10c adds read_at and seen_at to cassandra aggregatedactivity
e80106a merged
2bff045 fixes limit in queryset for cassandra timeline storage
2f40417 fixes bug with limiting cassandra queries
7ee0f41 changes default colunfamily name, added a sync_table to CassandraTimelineStorage.**init** -- this may not be the correct place
49a8846 passing activity along to get_user_follower_ids to allow selection of users related to object/target for fanout
